### PR TITLE
Update requirements for SPR1-833

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV PATH="$PATH_PYTHON3" VIRTUAL_ENV="$VIRTUAL_ENV_PYTHON3"
 
 # Install dependencies
 COPY --chown=kat:kat requirements.txt /tmp/install/requirements.txt
-RUN install-requirements.py -d ~/docker-base/base-requirements.txt -r /tmp/install/requirements.txt
+RUN install_pinned.py -r /tmp/install/requirements.txt
 
 # Install the current package
 COPY --chown=kat:kat . /tmp/install/katsdpmetawriter

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,30 +1,11 @@
+# TODO: switch to -c and unpin botocore once katsdpdockerbase updated.
+-d https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
+
 aiobotocore==1.1.2
-aiohttp                   # via aiobotocore
 aioitertools==0.7.1       # via aiobotocore
 aiokatcp
-aioredis                  # via katsdptelstate
 async_generator==1.10
-async-timeout             # via aiokatcp, aiohttp
-attrs                     # via aiohttp
 botocore==1.17.44         # via aiobotocore
-chardet                   # via aiohttp
-decorator                 # via aiokatcp
-docutils                  # via botocore
-hiredis
-idna                      # via yarl
-idna-ssl                  # via aiohttp
-jmespath                  # via botocore
-katversion
-msgpack                   # via katsdptelstate
-multidict                 # via aiohttp
-netifaces
-numpy
-pygelf
-python-dateutil           # via botocore
-redis                     # via katsdptelstate
-typing-extensions         # via aiobotocore, aiohttp
-urllib3                   # via botocore
 wrapt==1.12.1             # via aiobotocore
-yarl                      # via aiohttp
 katsdpservices @ git+https://github.com/ska-sa/katsdpservices
-katsdptelstate @ git+https://github.com/ska-sa/katsdptelstate
+katsdptelstate[aio] @ git+https://github.com/ska-sa/katsdptelstate

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,11 +18,11 @@ package_dir =
     = src
 packages = find:
 install_requires =
+    aiobotocore
     aiokatcp
     async_generator
-    aiobotocore
-    katsdptelstate[aio]
     katsdpservices
+    katsdptelstate[aio]
 scripts = scripts/meta_writer.py
 python_requires = >=3.6
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,10 +2,10 @@
 -c requirements.txt
 
 coverage
-katpoint==0.9                   # via katdal
 pytest
 pytest-asyncio==0.14.0
 pytest-cov
 pytest-mock==3.2.0
 
+katpoint @ git+https://github.com/ska-sa/katpoint     # via katdal
 katdal @ git+https://github.com/ska-sa/katdal

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,33 +1,11 @@
-attrs                           # via pytest
-certifi                         # via requests
-chardet                         # via requests
-cityhash                        # via katdal
+-c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
+-c requirements.txt
+
 coverage
-dask                            # via katdal
-ephem                           # via pyephem
-future                          # via katdal, katpoint
-h5py                            # via katdal
-idna                            # via requests
-importlib-metadata              # via pytest, pluggy
 katpoint==0.9                   # via katdal
-llvmlite                        # via numba
-more-itertools                  # via pytest
-numba                           # via katdal
-packaging                       # via pytest
-pluggy                          # via pytest
-py                              # via pytest
-pyephem                         # via katpoint
-pyjwt                           # via katdal
 pytest
 pytest-asyncio==0.14.0
 pytest-cov
 pytest-mock==3.2.0
-python-lzf                      # via katsdptelstate[rdb]
-rdbtools                        # via katsdptelstate[rdb]
-requests                        # via katdal
-toolz                           # via dask
-urllib3                         # via requests
-wcwidth                         # via pytest
-zipp                            # via importlib-metadata
 
 katdal @ git+https://github.com/ska-sa/katdal


### PR DESCRIPTION
- Add -c options to requirements files
- Strip down requirements files to remove recursive dependencies

For now requirements.txt can't use -c because it needs a specific
version of botocore (to keep aiobotocore happy). I'll sort that out
after doing a round of updates to base-requirements.txt.