### PR TITLE
Use katsdptelstate.aio.redis.RedisBackend.from_url

### DIFF
--- a/scripts/meta_writer.py
+++ b/scripts/meta_writer.py
@@ -22,7 +22,6 @@ import logging
 import asyncio
 import signal
 
-import aioredis
 import katsdptelstate.aio.redis
 import katsdpservices
 import katsdpmetawriter
@@ -36,8 +35,10 @@ def on_shutdown(loop, server):
 
 
 async def get_async_telstate(endpoint: katsdptelstate.endpoint.Endpoint):
-    client = await aioredis.create_redis_pool(f'redis://{endpoint.host}:{endpoint.port}')
-    return katsdptelstate.aio.TelescopeState(katsdptelstate.aio.redis.RedisBackend(client))
+    backend = await katsdptelstate.aio.redis.RedisBackend.from_url(
+        f'redis://{endpoint.host}:{endpoint.port}'
+    )
+    return katsdptelstate.aio.TelescopeState(backend)
 
 
 async def main():


### PR DESCRIPTION
This removes the direct dependency on aioredis, and so paves the way to
upgrading to 2.x.

Depends on https://github.com/ska-sa/katsdptelstate/pull/125.
